### PR TITLE
feat: 참가 요청 중 ProgressBar 표시하게 변경

### DIFF
--- a/app/src/main/java/kr/cosine/groupfinder/enums/TestGlobalUserData.kt
+++ b/app/src/main/java/kr/cosine/groupfinder/enums/TestGlobalUserData.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 object TestGlobalUserData {
 
 
-    var uuID: UUID? = UUID.fromString("f22b0151-5145-42ad-bbfb-4272b23fa57f")
+    var uuID: UUID? = null
     val HOST = 1
     val PARTICIPANT = 2
     val NONE = 3

--- a/app/src/main/java/kr/cosine/groupfinder/presentation/view/detail/DetailActivity.kt
+++ b/app/src/main/java/kr/cosine/groupfinder/presentation/view/detail/DetailActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -84,11 +85,10 @@ class DetailActivity : AppCompatActivity() {
             override fun onClick(view: View, lane: Lane) {
                 Log.d("test", "onClick: $lane, Empty") // 참가요청 보내는 로직
                 detailViewModel.postDetail.value?.let { post ->
-                    MyFirebaseMessagingService().sendJoinRequest(
-                        targetUUID = post.owner.uniqueId,
-                        senderUUID = uniqueId,
-                        lane = lane,
-                        postUUID = post.postUniqueId
+                    showJoinRequestDialog(
+                        ownerUniqueId = post.owner.uniqueId,
+                        postUniqueId = post.postUniqueId,
+                        lane = lane
                     )
                 } ?: run {
                     Log.e("test", "ownerUniqueId is null, unable to send join request")
@@ -105,9 +105,11 @@ class DetailActivity : AppCompatActivity() {
                             Log.d("test", "onExitClick: $userUUID 유저를 강퇴 하시겠습니까?")
                         }
                     }
+
                     PARTICIPANT -> {
                         Log.d("test", "onExitClick: 방을 나가겠습니까?")
                     }
+
                     else -> return
                 }
 
@@ -120,6 +122,25 @@ class DetailActivity : AppCompatActivity() {
             }
 
         }
+    }
+
+    private fun showJoinRequestDialog(ownerUniqueId: UUID, postUniqueId: UUID, lane: Lane) {
+        val builder = AlertDialog.Builder(this)
+        builder.setTitle("참가 요청")
+        builder.setMessage("${lane.displayName}라인에 참가하시겠습니까?")
+        builder.setPositiveButton("예") { _, _ ->
+            MyFirebaseMessagingService().sendJoinRequest(
+                targetUUID = ownerUniqueId,
+                senderUUID = uniqueId,
+                lane = lane,
+                postUUID = postUniqueId
+            )
+        }
+        builder.setNegativeButton("아니오") { dialog, _ ->
+            dialog.dismiss()
+        }
+        val dialog: AlertDialog = builder.create()
+        dialog.show()
     }
 
 }

--- a/app/src/main/java/kr/cosine/groupfinder/presentation/view/detail/DetailActivity.kt
+++ b/app/src/main/java/kr/cosine/groupfinder/presentation/view/detail/DetailActivity.kt
@@ -19,6 +19,7 @@ import kr.cosine.groupfinder.enums.Lane
 import kr.cosine.groupfinder.enums.TestGlobalUserData.HOST
 import kr.cosine.groupfinder.enums.TestGlobalUserData.PARTICIPANT
 import kr.cosine.groupfinder.presentation.view.common.data.IntentKey
+import kr.cosine.groupfinder.presentation.view.common.extension.setOnClickListenerWithCooldown
 import kr.cosine.groupfinder.util.MyFirebaseMessagingService
 import java.util.UUID
 
@@ -89,15 +90,17 @@ class DetailActivity : AppCompatActivity() {
     private fun laneOnClick() {
         laneAdapter.itemClick = object : DetailLaneAdapter.ItemClick {
             override fun onClick(view: View, lane: Lane) {
-                Log.d("test", "onClick: $lane, Empty") // 참가요청 보내는 로직
-                detailViewModel.postDetail.value?.let { post ->
-                    showJoinRequestDialog(
-                        ownerUniqueId = post.owner.uniqueId,
-                        postUniqueId = post.postUniqueId,
-                        lane = lane
-                    )
-                } ?: run {
-                    Log.e("test", "ownerUniqueId is null, unable to send join request")
+                view.setOnClickListenerWithCooldown(1000) {
+                    Log.d("test", "onClick: click!")
+                    detailViewModel.postDetail.value?.let { post ->
+                        showJoinRequestDialog(
+                            ownerUniqueId = post.owner.uniqueId,
+                            postUniqueId = post.postUniqueId,
+                            lane = lane
+                        )
+                    } ?: run {
+                        Log.e("test", "ownerUniqueId is null, unable to send join request")
+                    }
                 }
             }
 

--- a/app/src/main/java/kr/cosine/groupfinder/presentation/view/detail/DetailLaneAdapter.kt
+++ b/app/src/main/java/kr/cosine/groupfinder/presentation/view/detail/DetailLaneAdapter.kt
@@ -19,7 +19,7 @@ class DetailLaneAdapter : RecyclerView.Adapter<DetailLaneAdapter.Holder>() {
 
     interface ItemClick {
         fun onClick(view: View, lane: Lane)
-        fun onExitClick(view: View, lane: Lane, userName: UUID)
+        fun onExitClick(view: View, lane: Lane, userUUID: UUID)
     }
 
     var itemClick: ItemClick? = null

--- a/app/src/main/java/kr/cosine/groupfinder/presentation/view/detail/DetailLaneAdapter.kt
+++ b/app/src/main/java/kr/cosine/groupfinder/presentation/view/detail/DetailLaneAdapter.kt
@@ -53,7 +53,7 @@ class DetailLaneAdapter : RecyclerView.Adapter<DetailLaneAdapter.Holder>() {
             binding.selectIdTextView.text = text
 
             val isExitVisible = when(power) {
-                HOST -> true
+                HOST -> userInfo?.uniqueId != uniqueId
                 PARTICIPANT -> userInfo?.uniqueId == uniqueId
                 else -> false
             }

--- a/app/src/main/java/kr/cosine/groupfinder/util/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/kr/cosine/groupfinder/util/MyFirebaseMessagingService.kt
@@ -12,6 +12,7 @@ import kr.cosine.groupfinder.GroupFinderApplication
 import kr.cosine.groupfinder.R
 import kr.cosine.groupfinder.data.registry.LocalAccountRegistry.uniqueId
 import kr.cosine.groupfinder.enums.Lane
+import kr.cosine.groupfinder.presentation.view.detail.DetailActivity
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaType
@@ -32,7 +33,21 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
             val messageType = data["type"]
             when (messageType) {
                 "join_request" -> showJoinRequestDialog(myApp.getCurrentActivity(), data)
-                "join_denied" -> showJoinDeniedDialog(myApp.getCurrentActivity())
+                "join_denied" -> {
+                    val currentActivity = myApp.getCurrentActivity()
+                    if(currentActivity is DetailActivity) {
+                        currentActivity.dismissProgressDialog()
+                    }
+                    showJoinDeniedDialog(myApp.getCurrentActivity())
+                }
+                "join_accept" -> {
+                    val currentActivity = myApp.getCurrentActivity()
+                    val postUUID = UUID.fromString(data["postUUID"])
+                    if(currentActivity is DetailActivity) {
+                        currentActivity.dismissProgressDialog()
+                        currentActivity.reFreshGroupDetail(postUUID)
+                    }
+                }
                 "force_exit" -> showForceExitDialog(myApp.getCurrentActivity())
                 "already_cancel_request" -> showCanceledRequestDialog(myApp.getCurrentActivity())
                 "permissionDenied" -> showPermissionDeniedDialog(myApp.getCurrentActivity())


### PR DESCRIPTION
1. 참가 요청을 보내면 ProgressBar가 표현됩니다. 기본적으로 25초간 표기됩니다. 
2. 참가 거부 메세지가 정상적으로 돌아오면 해당 ProgressBar가 내려가고 거부 메세지가 표현됩니다.
3. 참가 승인시 ProgressBar가 사라지고, detail화면이 새로고침 됩니다. 

참가 요청이 안되던 버그가 어제밤에 있었습니다. 확인결과 참가중인 방 목록에 데이터가 들어가 있어서 그랬습니다. (enum - TestGlobalUserData - uuID) 해당 부분을 일시적으로 null로 바꿧습니다. 해당 부분은 임시조치입니다.

참가 요청의 경우 클릭시 dialog로 이중 확인을 추가하였습니다. 

